### PR TITLE
Handle multi-word class names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2
+
+# workflow definitions
+workflows:
+  version: 2
+  build:
+    jobs:
+      - rspec:
+          filters:
+            tags:
+              only: /.*/
+
+# test docker config
+docker: &TEST_DOCKER
+  - image: circleci/ruby:2.5.5-node-browsers
+    environment:
+      TZ: "America/Denver"
+
+rspec_steps: &RSPEC_STEPS
+  - checkout
+
+  # Restore cache
+  - restore_cache:
+      key: globalid-utils-{{ arch }}-{{ checksum "Gemfile.lock" }}
+  - run: bundle install --path vendor/bundle
+  - save_cache:
+      key: globalid-utils-{{ arch }}-{{ checksum "Gemfile.lock" }}
+      paths:
+        - vendor/bundle
+
+  # Run rspec in parallel
+  - run:
+      command: |
+        export SPEC_FILES_TO_RUN=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+        echo "Running spec files: $SPEC_FILES_TO_RUN"
+        bundle exec rspec --no-color --profile 10 --format RspecJunitFormatter --out test_results/rspec.xml $SPEC_FILES_TO_RUN
+
+  - store_artifacts:
+      path: test_results/rspec.xml
+
+  # Save test results for timing analysis
+  - store_test_results:
+      path: test_results
+
+# job definitions
+jobs:
+  rspec:
+    parallelism: 2
+    working_directory: ~/globalid-utils-ci
+    docker: *TEST_DOCKER
+    steps: *RSPEC_STEPS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     builder (3.2.3)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -47,6 +48,9 @@ GEM
     minitest (5.11.3)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -85,6 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   globalid-utils!
+  pry (~> 0.12)
   rake (= 12.3.0)
   rspec (= 3.6.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rspec_junit_formatter (0.3.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -92,6 +94,7 @@ DEPENDENCIES
   pry (~> 0.12)
   rake (= 12.3.0)
   rspec (= 3.6.0)
+  rspec_junit_formatter (~> 0.3.0)
 
 RUBY VERSION
    ruby 2.5.5p157

--- a/globalid-utils.gemspec
+++ b/globalid-utils.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake',  '12.3.0'
   s.add_development_dependency 'rspec', '3.6.0'
+  s.add_development_dependency 'pry',   '~> 0.12'
 end

--- a/globalid-utils.gemspec
+++ b/globalid-utils.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',  '12.3.0'
   s.add_development_dependency 'rspec', '3.6.0'
   s.add_development_dependency 'pry',   '~> 0.12'
+  s.add_development_dependency 'rspec_junit_formatter',    '~> 0.3.0'
 end

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -15,7 +15,7 @@ module GlobalIdUtils
       if gid.app.to_s == ::GlobalID.app.to_s
         gid.model_name.classify.constantize
       else
-        "#{gid.app.classify}::#{gid::model_name}".constantize
+        "#{gid.app.underscore.camelize}::#{gid::model_name}".constantize
       end
     end
     private_class_method :model_class_for

--- a/lib/global_id_utils/model_extensions.rb
+++ b/lib/global_id_utils/model_extensions.rb
@@ -72,7 +72,7 @@ module GlobalIdUtils
 
     def resolve_gid_app
       return self.class.class_variable_get(:@@gid_app) if self.class.class_variable_defined?(:@@gid_app)
-      return self.class.name.split('::').first.downcase if self.class.parent != ::Object
+      return self.class.name.split('::').first.underscore.dasherize if self.class.parent != ::Object
 
       ::GlobalID.app
     end

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -25,6 +25,23 @@ RSpec.describe GlobalIdUtils::Locator do
       described_class.locate('gid://fish/NeonTetra/1')
       expect(model_class).to have_received(:find).with('1')
     end
+
+    context 'when the app name is more than one word' do
+      let(:model_class) do
+        module AquaticLifeforms
+          class NeonTetra < Fish::Base
+          end
+        end
+
+        AquaticLifeforms::NeonTetra
+      end
+
+      it 'determines the model class and finds the record' do
+        allow(model_class).to receive(:find)
+        described_class.locate('gid://aquatic-lifeforms/NeonTetra/1')
+        expect(model_class).to have_received(:find).with('1')
+      end
+    end
   end
 
   describe '::locate_many' do

--- a/spec/global_id_utils/model_extensions_spec.rb
+++ b/spec/global_id_utils/model_extensions_spec.rb
@@ -20,7 +20,30 @@ RSpec.describe GlobalIdUtils::ModelExtensions do
   before { GlobalID.app = 'fish' }
   after  { Fish.send(:remove_const, 'NeonTetra') if Fish.const_defined?('NeonTetra') }
 
-  it { expect(subject.to_gid.to_s).to eq('gid://fish/NeonTetra/1') }
+  it 'generates a global id' do
+    expect(subject.to_gid.to_s).to eq('gid://fish/NeonTetra/1')
+  end
+
+  context 'when the class name is two words' do
+    let(:model_class) do
+      module AquaticLifeforms
+        class NeonTetra < Fish::Base
+        end
+      end
+
+      AquaticLifeforms::NeonTetra
+    end
+
+    it 'dasherizes the app name on words' do
+      expect(subject.to_gid.to_s).to eq('gid://aquatic-lifeforms/NeonTetra/1')
+    end
+
+    it 'can parse a dasherized app name' do
+      global_id = GlobalID.parse(subject.to_gid.to_s)
+      expect(global_id.model_name).to eq 'NeonTetra'
+      expect(global_id.app).to eq 'aquatic-lifeforms'
+    end
+  end
 
   describe '::gid_app' do
     let(:model_class) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 require 'globalid-utils'
+require 'pry'
 
 Dir[File.expand_path(File.join('../support', '**', '*.rb'), __FILE__)].each { |f| require f }


### PR DESCRIPTION
This should fix https://app.honeybadger.io/projects/55475/faults/37238108#notice-trace. ActiveStorage automatically enqueues a job to analyze blob contents, so `gid://activestorage/Blob/1` winds up getting passed in as the gid. This PR should change that gid to `gid://active-storage/Blob/1` to preserve the case.