### PR TITLE
Perform lookups using customm gid_model_id when it is defined on a model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globalid-utils (0.3.1)
+    globalid-utils (0.3.2)
       activemodel (~> 5.2.3)
       activesupport (~> 5.2.3)
       globalid (~> 0.4.0)

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -3,7 +3,7 @@ module GlobalIdUtils
     def self.locate(gid)
       gid = ::GlobalID.parse(gid)
       model_class = model_class_for(gid)
-      unscoped(model_class) { model_class.find(gid.model_id) }
+      unscoped(model_class) { model_class.find_by(model_class.gid_model_id_attribute => gid.model_id) }
     end
 
     def self.locate_many(gids, options = {})

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -3,7 +3,7 @@ module GlobalIdUtils
     def self.locate(gid)
       gid = ::GlobalID.parse(gid)
       model_class = model_class_for(gid)
-      unscoped(model_class) { model_class.find_by(model_class.gid_model_id_attribute => gid.model_id) }
+      unscoped(model_class) { find(model_class, gid.model_id) }
     end
 
     def self.locate_many(gids, options = {})
@@ -23,9 +23,9 @@ module GlobalIdUtils
     def self.find_records(model_class, ids, options)
       unscoped(model_class) do
         if options[:ignore_missing]
-          model_class.where(id: ids)
+          model_class.where(model_class.gid_model_id_attribute => ids)
         else
-          model_class.find(ids)
+          find(model_class, ids)
         end
       end.to_a
     end
@@ -39,5 +39,10 @@ module GlobalIdUtils
       end
     end
     private_class_method :unscoped
+
+    def self.find(model_class, id)
+      model_class.find_by(model_class.gid_model_id_attribute => id)
+    end
+    private_class_method :find
   end
 end

--- a/lib/global_id_utils/model_extensions.rb
+++ b/lib/global_id_utils/model_extensions.rb
@@ -34,11 +34,16 @@ module GlobalIdUtils
       end
 
       def gid_model_id(model_id)
-        unless model_id.is_a?(Symbol) || model_id.respond_to?(:call)
+        unless model_id.is_a?(Symbol)
           raise ArgumentError, 'Invalid model_id for GlobalID'
         end
 
         class_variable_set(:@@gid_model_id, model_id)
+      end
+
+      def gid_model_id_attribute
+        return :id unless class_variable_defined?(:@@gid_model_id)
+        class_variable_get(:@@gid_model_id)
       end
     end
 
@@ -85,17 +90,7 @@ module GlobalIdUtils
     end
 
     def resolve_gid_model_id
-      return id unless self.class.class_variable_defined?(:@@gid_model_id)
-
-      model_id = self.class.class_variable_get(:@@gid_model_id)
-
-      if model_id.is_a?(Symbol)
-        send(model_id)
-      elsif model_id.respond_to?(:call)
-        model_id.call(self)
-      else
-        id
-      end
+      send(self.class.gid_model_id_attribute)
     end
   end
 end

--- a/lib/global_id_utils/version.rb
+++ b/lib/global_id_utils/version.rb
@@ -1,3 +1,3 @@
 module GlobalIdUtils
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GlobalIdUtils::Locator do
   describe '::locate_many' do
     let(:second_model_class) do
       module Fish
-        class SiameseFighting
+        class SiameseFighting < Fish::Base
         end
       end
 
@@ -99,13 +99,13 @@ RSpec.describe GlobalIdUtils::Locator do
       neon1, neon3, neon5 = double, double, double
       siamese2, siamese4, siamese6 = double, double, double
 
-      allow(model_class).to receive(:find).with(['1', '3', '5']).and_return([neon1, neon3, neon5])
-      allow(second_model_class).to receive(:find).with(['2', '4', '6']).and_return([siamese2, siamese4, siamese6])
+      allow(model_class).to receive(:find_by).with(id: ['1', '3', '5']).and_return([neon1, neon3, neon5])
+      allow(second_model_class).to receive(:find_by).with(id: ['2', '4', '6']).and_return([siamese2, siamese4, siamese6])
 
       result = described_class.locate_many(gids)
 
-      expect(model_class).to have_received(:find).once
-      expect(second_model_class).to have_received(:find).once
+      expect(model_class).to have_received(:find_by).once
+      expect(second_model_class).to have_received(:find_by).once
       expect(result).to contain_exactly(neon1, neon3, neon5, siamese2, siamese4, siamese6)
     end
 

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe GlobalIdUtils::Locator do
     end
 
     it 'determines the model class and finds the record' do
-      allow(model_class).to receive(:find)
+      allow(model_class).to receive(:find_by)
       described_class.locate('gid://fish/NeonTetra/1')
-      expect(model_class).to have_received(:find).with('1')
+      expect(model_class).to have_received(:find_by).with(id: '1')
     end
 
     context 'when the app name is more than one word' do
@@ -37,9 +37,27 @@ RSpec.describe GlobalIdUtils::Locator do
       end
 
       it 'determines the model class and finds the record' do
-        allow(model_class).to receive(:find)
+        allow(model_class).to receive(:find_by)
         described_class.locate('gid://aquatic-lifeforms/NeonTetra/1')
-        expect(model_class).to have_received(:find).with('1')
+        expect(model_class).to have_received(:find_by).with(id: '1')
+      end
+    end
+
+    context 'when the model defines a custom model ID attribute' do
+      let(:model_class) do
+        module Fish
+          class NeonTetra < Fish::Base
+            gid_model_id :public_id
+          end
+        end
+
+        Fish::NeonTetra
+      end
+
+      it 'finds the model by the custom attribute' do
+        allow(model_class).to receive(:find_by)
+        described_class.locate('gid://fish/NeonTetra/public-id-1')
+        expect(model_class).to have_received(:find_by).with(public_id: 'public-id-1')
       end
     end
   end

--- a/spec/global_id_utils/model_extensions_spec.rb
+++ b/spec/global_id_utils/model_extensions_spec.rb
@@ -86,4 +86,37 @@ RSpec.describe GlobalIdUtils::ModelExtensions do
 
     it { expect(subject.to_gid.to_s).to eq('gid://fish/NeonTetra/Pedro') }
   end
+
+  describe '::gid_model_id_attribute' do
+    context 'when a custom model ID is defined' do
+      let(:model_class) do
+        module Fish
+          class NeonTetra < Base
+            gid_model_id :name
+          end
+        end
+
+        Fish::NeonTetra
+      end
+
+      it 'returns the custom attribute' do
+        expect(subject.class.gid_model_id_attribute).to eq(:name)
+      end
+    end
+
+    context 'when a custom model ID is not defined' do
+      let(:model_class) do
+        module Fish
+          class NeonTetra < Base
+          end
+        end
+
+        Fish::NeonTetra
+      end
+
+      it 'returns the custom attribute' do
+        expect(subject.class.gid_model_id_attribute).to eq(:id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previous to this commit, it was possible for a class to define a custom
model attribute to use when generating a GID. E.g.

```
class SiameseFighting < ActiveRecord::Base
  gid_model_id :name
end
```

However, the attribute defined by `::gid_model_id` was not used when
using the GID to lookup a model instance.

This commit fixes this bug by using `find_by(<gid_model_id_attribute>:
<model_id>)` when performing a lookup in
`::GlobalIdUtils::Locator.locate`. In addition to this core change, this
commit removes the ability to pass a callable object into `::gid_model_id`.
The callable pattern increased the complexity of the lookup code and is
unused by consumers of this gem (Portal).