### PR TITLE
Fix find many bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globalid-utils (0.3.2)
+    globalid-utils (0.3.3)
       activemodel (~> 5.2.3)
       activesupport (~> 5.2.3)
       globalid (~> 0.4.0)

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -3,7 +3,7 @@ module GlobalIdUtils
     def self.locate(gid)
       gid = ::GlobalID.parse(gid)
       model_class = model_class_for(gid)
-      unscoped(model_class) { find(model_class, gid.model_id) }
+      unscoped(model_class) { model_class.find_by(model_class.gid_model_id_attribute => gid.model_id) }
     end
 
     def self.locate_many(gids, options = {})
@@ -21,12 +21,28 @@ module GlobalIdUtils
     private_class_method :model_class_for
 
     def self.find_records(model_class, ids, options)
+      ids = [ids] unless ids.is_a?(Array)
+      ids = ids.compact.uniq
+
       unscoped(model_class) do
-        if options[:ignore_missing]
-          model_class.where(model_class.gid_model_id_attribute => ids)
-        else
-          find(model_class, ids)
+        rel = model_class.where(model_class.gid_model_id_attribute => ids)
+
+        unless options[:ignore_missing]
+          found_ids = rel.pluck(model_class.gid_model_id_attribute)
+          not_found_ids = ids.map(&:to_s) - found_ids.map(&:to_s)
+
+          if ids.count != found_ids.count
+            rel.raise_record_not_found_exception!(
+              ids,
+              found_ids.count,
+              ids.count,
+              model_class.gid_model_id_attribute,
+              not_found_ids,
+            )
+          end
         end
+
+        rel
       end.to_a
     end
     private_class_method :find_records
@@ -39,10 +55,5 @@ module GlobalIdUtils
       end
     end
     private_class_method :unscoped
-
-    def self.find(model_class, id)
-      model_class.find_by(model_class.gid_model_id_attribute => id)
-    end
-    private_class_method :find
   end
 end

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -21,7 +21,6 @@ module GlobalIdUtils
     private_class_method :model_class_for
 
     def self.find_records(model_class, ids, options)
-      ids = [ids] unless ids.is_a?(Array)
       ids = ids.compact.uniq
 
       unscoped(model_class) do

--- a/lib/global_id_utils/version.rb
+++ b/lib/global_id_utils/version.rb
@@ -1,3 +1,3 @@
 module GlobalIdUtils
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end


### PR DESCRIPTION
## Expected behaviour

When a user passes a set of GIDs into
`GlobalIdsUtils::Locator.locate_many` they expect to receive all records
which match the provided GIDs.

Furthermore, if a user does not specify the `ignore_missing` param when
calling `#locate_many`, the expectation is that an
`ActiveRecord::RecordNotFound` exception is raised if any records cannot
be found given the provided GIDs.

## Bug

In 149ba02, we shifted the logic in `::locate_many` to use `find_by`
instead of `find`. This allowed support for lookups by other attributes
than the model's primary key. This was an attempt to fix a separate bug
wherein `::locate_many` did not respect a custom gid_model_id attribute
defined by the model class.

However, in making this change, we removed two critical behaviours of
`::locate_many`. First, `find_by` will only return one record when many
are expected. Second, `find_by` will not raise an error if a record
cannot be found.

## Fix

This commit shifts the logic in `::locate_many` to use a `where` clause
to select records which match the provided GIDs. Additionally, logic is
added to raise an `ActiveRecord::RecordNotFound` exception if a record
could not be found for all of the provided GIDs.