### PR TITLE
Raise when cannot be found

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    globalid-utils (0.3.3)
+    globalid-utils (0.3.4)
       activemodel (~> 5.2.3)
       activesupport (~> 5.2.3)
       globalid (~> 0.4.0)

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -3,7 +3,7 @@ module GlobalIdUtils
     def self.locate(gid)
       gid = ::GlobalID.parse(gid)
       model_class = model_class_for(gid)
-      unscoped(model_class) { model_class.find_by(model_class.gid_model_id_attribute => gid.model_id) }
+      unscoped(model_class) { model_class.find_by!(model_class.gid_model_id_attribute => gid.model_id) }
     end
 
     def self.locate_many(gids, options = {})

--- a/lib/global_id_utils/version.rb
+++ b/lib/global_id_utils/version.rb
@@ -1,3 +1,3 @@
 module GlobalIdUtils
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.4'.freeze
 end

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe GlobalIdUtils::Locator do
     end
 
     it 'determines the model class and finds the record' do
-      allow(model_class).to receive(:find_by)
+      allow(model_class).to receive(:find_by!)
       described_class.locate('gid://fish/NeonTetra/1')
-      expect(model_class).to have_received(:find_by).with(id: '1')
+      expect(model_class).to have_received(:find_by!).with(id: '1')
     end
 
     context 'when the app name is more than one word' do
@@ -37,9 +37,9 @@ RSpec.describe GlobalIdUtils::Locator do
       end
 
       it 'determines the model class and finds the record' do
-        allow(model_class).to receive(:find_by)
+        allow(model_class).to receive(:find_by!)
         described_class.locate('gid://aquatic-lifeforms/NeonTetra/1')
-        expect(model_class).to have_received(:find_by).with(id: '1')
+        expect(model_class).to have_received(:find_by!).with(id: '1')
       end
     end
 
@@ -55,9 +55,9 @@ RSpec.describe GlobalIdUtils::Locator do
       end
 
       it 'finds the model by the custom attribute' do
-        allow(model_class).to receive(:find_by)
+        allow(model_class).to receive(:find_by!)
         described_class.locate('gid://fish/NeonTetra/public-id-1')
-        expect(model_class).to have_received(:find_by).with(public_id: 'public-id-1')
+        expect(model_class).to have_received(:find_by!).with(public_id: 'public-id-1')
       end
     end
   end


### PR DESCRIPTION
# What this PR does

When a record cannot be found by Loacator.locate, raise ActiveRecord::RecordNotFound

This fixes a regression introduced in 3726394 which replaced `::find`
with `::find_by` when looking up a record. `::find` will raise if a
record is not found while `::find_by` will not raise. This commit
replaces `::find_by` with `::find_by!` to preserve the behaviour of
`::find`.

# Additional Context

For the avoidance of doubt, here is the behavior in production right now:

```ruby
irb(main):001:0> ::GlobalID.find('gid://borrower/Organization/101001011')
Traceback (most recent call last):
        1: from (irb):1
ActiveRecord::RecordNotFound (Couldn't find Borrower::Organization with 'id'=101001011)
```

On my Portal branch running 0.3.3:
```
[1] pry(main)> ::GlobalID.find('gid://borrower/Organization/101001011')
=> nil
```

On my Portal branch running 0.3.4:
```
[1] pry(main)> ::GlobalID.find('gid://borrower/Organization/101001011')
ActiveRecord::RecordNotFound: Couldn't find Borrower::Organization
from /Users/alex/src_wunder/portal/.bundle/lib/ruby/2.5.0/gems/activerecord-5.2.3/lib/active_record/core.rb:217:in `find_by!'
```