### PR TITLE
Security update: Bump globalid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     globalid-utils (0.3.4)
       activemodel (~> 6.0.4)
       activesupport (~> 6.0.4)
-      globalid (~> 0.4.2)
+      globalid (~> 1.0, >= 1.0.1)
       railties (~> 6.0.4)
 
 GEM
@@ -37,16 +37,16 @@ GEM
     crass (1.0.6)
     diff-lcs (1.5.0)
     erubi (1.10.0)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
-    i18n (1.10.0)
+    globalid (1.0.1)
+      activesupport (>= 5.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.17.0)
     nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -86,9 +86,9 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     thor (1.2.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   ruby
@@ -104,4 +104,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.31
+   2.3.18

--- a/globalid-utils.gemspec
+++ b/globalid-utils.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel',    '~> 6.0.4'
   s.add_dependency 'activesupport',  '~> 6.0.4'
-  s.add_dependency 'globalid',       '~> 0.4.2'
+  s.add_dependency 'globalid',       '~> 1.0', '>= 1.0.1'
   s.add_dependency 'railties',       '~> 6.0.4'
 
   s.add_development_dependency 'rake',  '12.3.3'


### PR DESCRIPTION
The current versions of this gem includes a low-risk security vulnerability. This PR bump remediates that.

In addition, now that globalid has reached a stable API, it no longer pins the gem to a specific version. This will make it so that we can upgrade globalid to newer minor or patch versions in other repos (e.g., portal), and the version constraints in this repo preventing us from doing so.

Upgrading portal's globalid gem is the impetus for this PR.