### PR TITLE
Add platforms and update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,10 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     minitest (5.17.0)
+    nokogiri (1.14.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.2)
@@ -88,6 +92,9 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin
+  ruby
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,4 +108,4 @@ RUBY VERSION
    ruby 3.2.1p31
 
 BUNDLED WITH
-   2.4.6
+   2.4.8


### PR DESCRIPTION
[In a previous PR, dependabot changed our platforms](https://github.com/wunderteam/globalid-utils/pull/21), which was unexpected. I think this change prevent future changes when dependabot creates a fix.