### PR TITLE
Workflow for reporting dependabot vulnerabilities to slack

### DIFF
--- a/.github/workflows/dependabot-vulns-to-slack.yaml
+++ b/.github/workflows/dependabot-vulns-to-slack.yaml
@@ -1,0 +1,16 @@
+name: 'Dependabot Vulnerabilities to Slack'
+
+# Every Weekday at 9AM
+# https://crontab.guru/#0_9_*_*_1-5
+on:
+  schedule:
+    - cron: "0 9 * * 1-5"
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kunalnagarco/action-cve@v1.7.15
+        with:
+          token: ${{ secrets.SLACK_GITHUB_ACCESS_TOKEN }}
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Copy of what we do for Portal - https://github.com/wunderteam/portal/blob/master/.github/workflows/dependabot-vulns-to-slack.yaml

These secrets are now in our org so they should be available for this repo

I'm not aware of any more sharing that can be done. We are already using a shared workflow to do most of this work, I think the copy paste works well enough for this. 