### PR TITLE
Fix GlobalID#model_class

### DIFF
--- a/lib/global_id_utils.rb
+++ b/lib/global_id_utils.rb
@@ -39,4 +39,8 @@ class GlobalID
     gids = gids.map { |gid| new(gid) }
     find_many(gids, options)
   end
+
+  def model_class
+    ::GlobalIdUtils::Locator.model_class_for(self)
+  end
 end

--- a/lib/global_id_utils.rb
+++ b/lib/global_id_utils.rb
@@ -41,6 +41,10 @@ class GlobalID
   end
 
   def model_class
-    ::GlobalIdUtils::Locator.model_class_for(self)
+    if self.app.to_s == ::GlobalID.app.to_s
+      self.model_name.classify.constantize
+    else
+      "#{self.app.underscore.camelize}::#{self.model_name}".constantize
+    end
   end
 end

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -22,7 +22,6 @@ module GlobalIdUtils
         "#{gid.app.underscore.camelize}::#{gid::model_name}".constantize
       end
     end
-    private_class_method :model_class_for
 
     def self.find_records(model_class, ids, options)
       ids = ids.compact.uniq

--- a/lib/global_id_utils/locator.rb
+++ b/lib/global_id_utils/locator.rb
@@ -2,7 +2,7 @@ module GlobalIdUtils
   module Locator
     def self.locate(gid, scopes = [])
       gid = ::GlobalID.parse(gid)
-      model_class = model_class_for(gid)
+      model_class = gid.model_class
       unscoped(model_class) do
         relation = model_class
         scopes.each { |scope| relation.send(scope.name, *scope.args) }
@@ -11,16 +11,8 @@ module GlobalIdUtils
     end
 
     def self.locate_many(gids, options = {})
-      models_and_ids = gids.each_with_object({}) { |gid, hsh| (hsh[model_class_for(gid)] ||= []) << gid.model_id }
+      models_and_ids = gids.each_with_object({}) { |gid, hsh| (hsh[gid.model_class] ||= []) << gid.model_id }
       models_and_ids.map { |model_class, ids| find_records(model_class, ids, options) }.flatten
-    end
-
-    def self.model_class_for(gid)
-      if gid.app.to_s == ::GlobalID.app.to_s
-        gid.model_name.classify.constantize
-      else
-        "#{gid.app.underscore.camelize}::#{gid::model_name}".constantize
-      end
     end
 
     def self.find_records(model_class, ids, options)

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -149,4 +149,12 @@ RSpec.describe GlobalIdUtils::Locator do
       end.to raise_error('boom!')
     end
   end
+
+  describe '::model_class_for' do
+    it 'returns the model class for the given GID' do
+      model_class
+      gid = GlobalID.parse('gid://aquatic-lifeforms/NeonTetra/1')
+      expect(described_class.send(:model_class_for, gid)).to eq(AquaticLifeforms::NeonTetra)
+    end
+  end
 end

--- a/spec/global_id_utils/locator_spec.rb
+++ b/spec/global_id_utils/locator_spec.rb
@@ -149,12 +149,4 @@ RSpec.describe GlobalIdUtils::Locator do
       end.to raise_error('boom!')
     end
   end
-
-  describe '::model_class_for' do
-    it 'returns the model class for the given GID' do
-      model_class
-      gid = GlobalID.parse('gid://aquatic-lifeforms/NeonTetra/1')
-      expect(described_class.send(:model_class_for, gid)).to eq(AquaticLifeforms::NeonTetra)
-    end
-  end
 end

--- a/spec/global_id_utils_spec.rb
+++ b/spec/global_id_utils_spec.rb
@@ -120,4 +120,23 @@ RSpec.describe 'GlobalID extensions' do
       end
     end
   end
+
+  describe 'GlobalID#model_class' do
+    let!(:model_class) do
+      module Fish
+        class NeonTetra < Base
+        end
+      end
+
+      ::Fish::NeonTetra
+    end
+
+    before { GlobalID.app = 'testapp' }
+    after { Fish.send(:remove_const, 'NeonTetra') if Fish.const_defined?('NeonTetra') }
+
+    it 'returns the model class for the gid' do
+      gid = GlobalID.new('gid://fish/NeonTetra/1')
+      expect(gid.model_class).to eq(::Fish::NeonTetra)
+    end
+  end
 end


### PR DESCRIPTION
# Purpose
Today getting a `model_class` for our custom GlobalIDs throws an error:
```
gid = "gid://borrower/Project/332332"
wunder(dev)> GlobalID.parse(gid).model_class
(wunder):6:in `<main>': uninitialized constant Project (NameError)

      Object.const_get(camel_cased_word)
            ^^^^^^^^^^
Did you mean?  Projects
``` 

This is due to our custom implementation of the ids. 

Here we overwrite the `model_class` method with our implementation, so we can do:
```
wunder(dev)> gid = "gid://borrower/Project/332332"
=> "gid://borrower/Project/332332"
wunder(dev)> GlobalID.parse(gid).model_class
=> Borrower::Project
```