### PR TITLE
rescue and return nil rather than exception on model_class

### DIFF
--- a/lib/global_id_utils.rb
+++ b/lib/global_id_utils.rb
@@ -46,5 +46,7 @@ class GlobalID
     else
       "#{self.app.underscore.camelize}::#{self.model_name}".constantize
     end
+  rescue NameError
+    nil
   end
 end

--- a/spec/global_id_utils_spec.rb
+++ b/spec/global_id_utils_spec.rb
@@ -138,5 +138,10 @@ RSpec.describe 'GlobalID extensions' do
       gid = GlobalID.new('gid://fish/NeonTetra/1')
       expect(gid.model_class).to eq(::Fish::NeonTetra)
     end
+
+    it 'returns nil when the model class cannot be constantized' do
+      gid = GlobalID.new('gid://fish/NonExistentModel/1')
+      expect(gid.model_class).to be_nil
+    end
   end
 end


### PR DESCRIPTION
# What this PR Does
Rescue instead of causing an exception if the model_class doesn't exist

# How to Test
I added a spec for this